### PR TITLE
Fix NameError for methods an object responds_to but doesn't have as a public_method

### DIFF
--- a/lib/quacky/duck_type_verifier.rb
+++ b/lib/quacky/duck_type_verifier.rb
@@ -10,16 +10,18 @@ module Quacky
       duck_type_methods.each do |method|
         raise Quacky::DuckTypeVerificationFailure, "object does not respond to `#{method.name}'" unless object.respond_to?(method.name)
 
-        target_method = object.public_method(method.name)
-        return true if target_method.parameters.any? { |p| p.first == :rest }
+        begin
+          target_method = object.public_method(method.name)
+          return true if target_method.parameters.any? { |p| p.first == :rest }
 
-        method_parameters = method.parameters.reject { |p| p.first == :block }
-        target_method_parameters = target_method.parameters.reject { |p| p.first == :block }
+          method_parameters = method.parameters.reject { |p| p.first == :block }
+          target_method_parameters = target_method.parameters.reject { |p| p.first == :block }
 
-        if target_method_parameters.count != method_parameters.count ||
-           target_method_parameters.map {|p| p.first } != method_parameters.map {|p| p.first}
-          raise Quacky::DuckTypeVerificationFailure, "definitions of method `#{method.name}` differ in parameters accepted."
-        end
+          if target_method_parameters.count != method_parameters.count ||
+             target_method_parameters.map {|p| p.first } != method_parameters.map {|p| p.first}
+            raise Quacky::DuckTypeVerificationFailure, "definitions of method `#{method.name}` differ in parameters accepted."
+          end
+        rescue NameError; end
 
         true
       end

--- a/spec/lib/duck_type_verifier_spec.rb
+++ b/spec/lib/duck_type_verifier_spec.rb
@@ -75,5 +75,23 @@ describe Quacky::DuckTypeVerifier do
         expect { verifier.verify! conforming_object }.not_to raise_exception Quacky::DuckTypeVerificationFailure
       end
     end
+
+    context "given an object that responds to but does not explicitly implement a method" do
+      let(:unexplicitly_conforming_object) do
+        Class.new do
+          def respond_to?(method_name, include_private = false)
+            method_name.to_s == 'quack' || super
+          end
+        end.new
+      end
+
+      it "should not raise a DuckTypeVerificationError" do
+        expect { verifier.verify! conforming_object }.not_to raise_exception Quacky::DuckTypeVerificationFailure
+      end
+
+      it "should not raise a NameError" do
+        expect { verifier.verify! conforming_object }.not_to raise_exception NameError
+      end
+    end
   end
 end


### PR DESCRIPTION
Hey Parker! Here's a quick fix I wrote for quacky that allows the verifier to pass an object if it responds_to an interface method, but the method isn't found by public_method. Previously, it would raise a NameError. I found this problem when trying to call delegated methods on a Draper object, but I imagine it's a common occurrence--it seems to happen for classes that make use of method_missing but override responds_to? instead of responds_to_missing?.

Let me know what you think.
