### PR TITLE
Fix splatted methods

### DIFF
--- a/lib/quacky/duck_type_verifier.rb
+++ b/lib/quacky/duck_type_verifier.rb
@@ -12,7 +12,7 @@ module Quacky
 
         begin
           target_method = object.public_method(method.name)
-          return true if target_method.parameters.any? { |p| p.first == :rest }
+          next if target_method.parameters.any? { |p| p.first == :rest }
 
           method_parameters = method.parameters.reject { |p| p.first == :block }
           target_method_parameters = target_method.parameters.reject { |p| p.first == :block }

--- a/spec/lib/duck_type_verifier_spec.rb
+++ b/spec/lib/duck_type_verifier_spec.rb
@@ -4,12 +4,14 @@ describe Quacky::DuckTypeVerifier do
   let(:conforming_object) do
     Class.new do
       def quack arg1,arg2,arg3=nil; end
+      def waddle; end
     end.new
   end
 
   let(:duck_type_module) do
     Module.new do
       def quack a,b,c=nil; end
+      def waddle; end
     end
   end
 
@@ -41,22 +43,14 @@ describe Quacky::DuckTypeVerifier do
     end
 
     context "given a conforming object" do
-      let(:conforming_object) do
-        Class.new do
-          def quack arg1,arg2,arg3=nil; end
-        end.new
-      end
-
       it "should return true" do
         expect { verifier.verify! conforming_object }.not_to raise_exception Quacky::DuckTypeVerificationFailure
       end
     end
 
     context "given a method that accepts any number of arguments" do
-      let(:conforming_object) do
-        Class.new do
-          def quack *args; end
-        end.new
+      before do
+        def conforming_object.quack(*args); end
       end
 
       it "should return true" do
@@ -65,10 +59,8 @@ describe Quacky::DuckTypeVerifier do
     end
 
     context "given a method that accepts a named block" do
-      let(:conforming_object) do
-        Class.new do
-          def quack arg1,arg2,arg3=nil,&block; end
-        end.new
+      before do
+        def conforming_object.quack(arg1,arg2,arg3=nil,&block); end
       end
 
       it "should return true" do

--- a/spec/lib/duck_type_verifier_spec.rb
+++ b/spec/lib/duck_type_verifier_spec.rb
@@ -49,12 +49,26 @@ describe Quacky::DuckTypeVerifier do
     end
 
     context "given a method that accepts any number of arguments" do
-      before do
-        def conforming_object.quack(*args); end
+      context "when the object conforms" do
+        before do
+          def conforming_object.quack(*args); end
+        end
+
+        it "should return true" do
+          expect { verifier.verify! conforming_object }.not_to raise_exception Quacky::DuckTypeVerificationFailure
+        end
       end
 
-      it "should return true" do
-        expect { verifier.verify! conforming_object }.not_to raise_exception Quacky::DuckTypeVerificationFailure
+      context "when the object does not conform" do
+        let(:non_conforming_object) do
+          Class.new do
+            def quack(*args); end
+          end.new
+        end
+
+        it "raises a Quacky::DuckTypeVerificationFailure" do
+          expect { verifier.verify! non_conforming_object }.to raise_exception Quacky::DuckTypeVerificationFailure
+        end
       end
     end
 


### PR DESCRIPTION
If an implemented method accepted a splat for args, the "return" inside the iterator would exit from the iteration, rather than just skip to the next element.
